### PR TITLE
Escape the `*` regex.

### DIFF
--- a/switcher.sh
+++ b/switcher.sh
@@ -22,7 +22,7 @@ device=`wpctl status | grep -A3 -m 1 Sinks | tail -n 3 | grep $anotherDevice | g
 
 
 
-if [[ "$(wpctl status | grep -A3 -m 1 Sinks | tail -n 3 | grep "*")" = *"$headphonesName"* ]]; then	
+if [[ "$(wpctl status | grep -A3 -m 1 Sinks | tail -n 3 | grep "\*")" = *"$headphonesName"* ]]; then	
 	let nonActive=$device
 	nonActiveName=$anotherDevice
 	nonActiveIcon=speaker


### PR DESCRIPTION
I (and other as well I assume) are using ripgrep and have it aliased as `regex`.
Ripgrep doesn't like it when you try to search for a single star and complains. Escaping the star fixes rg and doesn't affect regex either so I think it's ideal 
